### PR TITLE
Verify workflow commit SHA against list of SHAs in repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,29 @@ The `sha` of the workflow-commit is set as output-parameter. If no matching work
 ```yml
       - uses: actions/checkout@v2
       - name: Find matching workflow
-        uses: SamhammerAG/last-successful-build-action@v1
+        uses: SamhammerAG/last-successful-build-action@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           branch: "development"
           workflow: "build"
 ```
 
-## Config
+## Verifying workflow run SHAs
+If your workflow runs are expected to contain no-longer existing commit SHAs (e.g. when squashing and force pushing) you need to verify the SHA of the workflow run commit against the list of commit SHAs in your repository.
 
+```yml
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # check out the entire repo history for SHA verification
+      - name: Find matching workflow
+        uses: SamhammerAG/last-successful-build-action@v2
+        with:
+          branch: "development"
+          workflow: "build"
+          verify: true
+```
+
+## Config
 ### Action inputs
 
 | Name | Description | Default |
@@ -24,6 +38,7 @@ The `sha` of the workflow-commit is set as output-parameter. If no matching work
 | `token` | `GITHUB_TOKEN` or a `repo` scoped [PAT](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). | `GITHUB_TOKEN` |
 | `branch` | Branch for the workflow to look for. | "" |
 | `workflow` | Workflow name to look for. | "" |
+| `verify` | Verify workflow commit SHA against list of SHAs in repository | `false` |
 
 
 ### Action outputs

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
   workflow:
     description: 'Workflow name to look for.'
     required: false
+  verify:
+    description: 'Verify SHA of workflow run commit against list of commit SHAs in repository'
+    required: false
+    default: 'false'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,222 @@
 {
   "name": "last-successful-build-action",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "~1.2.7",
+        "@actions/github": "~4.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "~14.14.9",
+        "@vercel/ncc": "~0.28.3",
+        "typescript": "~4.2.4"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.7.tgz",
+      "integrity": "sha512-kzLFD5BgEvq6ubcxdgPbRKGD2Qrgya/5j+wh4LZzqT915I0V3rED+MvjH6NXghbvk1MXknpNNQ3uKjXSEN00Ig=="
+    },
+    "node_modules/@actions/github": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
+      "integrity": "sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==",
+      "dependencies": {
+        "@actions/http-client": "^1.0.8",
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.3",
+        "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dependencies": {
+        "tunnel": "0.0.6"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
+      "dependencies": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
+      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
+      "dependencies": {
+        "@octokit/types": "^6.11.0"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.15.1.tgz",
+      "integrity": "sha512-4gQg4ySoW7ktKB0Mf38fHzcSffVZd6mT5deJQtpqkuPuAqzlED5AJTeW8Uk7dPRn7KaOlWcXB0MedTFJU1j4qA==",
+      "dependencies": {
+        "@octokit/types": "^6.13.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.4.15",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
+      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
+      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
+      "dependencies": {
+        "@octokit/openapi-types": "^10.1.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "dev": true
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.28.3.tgz",
+      "integrity": "sha512-g3gk4D9itbhUQa5MtN7TOdeoQnNLkPDCox5SBaQ/H3Or5lo59TOaZWrLb+x47StiAJ+8DXZS/9MJ67cIBWSsRw==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.1.tgz",
+      "integrity": "sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw=="
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  },
   "dependencies": {
     "@actions/core": {
       "version": "1.2.7",
@@ -71,9 +285,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.1.0.tgz",
-      "integrity": "sha512-Z9fDZVbGj4dFLErEoXUSuZhk3wJ8KVGnbrUwoPijsQ9EyNwOeQ+U2jSqaHUz8WtgIWf0aeO59oJyhMpWCKaabg=="
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
+      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.13.3",
@@ -116,11 +330,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.1.tgz",
-      "integrity": "sha512-UF/PL0y4SKGx/p1azFf7e6j9lB78tVwAFvnHtslzOJ6VipshYks74qm9jjTEDlCyaTmbhbk2h3Run5l0CtCF6A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
+      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
       "requires": {
-        "@octokit/openapi-types": "^6.0.0"
+        "@octokit/openapi-types": "^10.1.0"
       }
     },
     "@types/node": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,41 @@
 import * as core from '@actions/core'
 import * as github from "@actions/github";
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+let repoShas: string[] | undefined;
+
+const verifyCommit =  async (sha: string): Promise<boolean> => {
+    if (!repoShas) {
+        try {
+            const cmd = `git log --format=format:%H`;
+            core.info(`Getting list of SHAs in repo via command "${cmd}"`);
+
+            const { stdout } = await execAsync(cmd);
+
+            repoShas = stdout.trim().split('\n');
+        } catch (e) {
+            repoShas = [];
+            core.warning(`Error while attempting to get list of SHAs: ${e.message}`);
+
+            return false;
+        }
+    }
+
+    core.info(`Looking for SHA ${sha} in repo SHAs`);
+
+    return repoShas.includes(sha);
+}
 
 async function run(): Promise<void> {
     try {
         const inputs = {
             token: core.getInput("token"),
             branch: core.getInput("branch"),
-            workflow: core.getInput("workflow")
+            workflow: core.getInput("workflow"),
+            verify: core.getInput('verify')
         };
 
         const octokit = github.getOctokit(inputs.token);
@@ -28,22 +57,39 @@ async function run(): Promise<void> {
             .filter(x => (!inputs.branch || x.head_branch === inputs.branch) && x.conclusion === "success")
             .sort((r1, r2) => new Date(r2.created_at).getTime() - new Date(r1.created_at).getTime());
 
-        let sha = process.env.GITHUB_SHA as string;
+        let triggeringSha = process.env.GITHUB_SHA as string;
+        let sha: string | undefined = undefined;
         
         if (runs.length > 0) {
-            const run = runs[0];
+            for (const run of runs) {
+                core.debug(`This SHA: ${triggeringSha}`);
+                core.debug(`Run SHA: ${run.head_sha}`);
+                core.debug(`Run Branch: ${run.head_branch}`);
+                core.debug(`Wanted branch: ${inputs.branch}`);
 
-            core.info(`This SHA: ${sha}`);
-            core.info(`Run SHA: ${run.head_sha}`);
-            core.info(`Run Branch: ${run.head_branch}`);
-            core.info(`Wanted branch: ${inputs.branch}`);
+                if (triggeringSha != run.head_sha && (!inputs.branch || run.head_branch === inputs.branch)) {
+                    if (inputs.verify && !await verifyCommit(run.head_sha)) {
+                        core.warning(`Failed to verify commit ${run.head_sha}. Skipping.`);
+                        continue;
+                    }
 
-            if (sha != run.head_sha && (!inputs.branch || run.head_branch === inputs.branch)) {
-                core.info(`Using extracted sha ${run.head_sha} from run ${run.html_url} instead of triggering sha ${sha}.`);
-                sha = run.head_sha;
+                    core.info(
+                      inputs.verify
+                      ? `Commit ${run.head_sha} from run ${run.html_url} verified as last successful CI run.`
+                      : `Using ${run.head_sha} from run ${run.html_url} as last successful CI run.`
+                    );
+                    sha = run.head_sha;
+
+                    break;
+                }
             }
         } else {
-            core.warning("No recent workflow-run's found, use sha of this run!");
+            core.info(`No previous runs found for branch ${inputs.branch}.`);
+        }
+
+        if (!sha) {
+            core.warning("Unable to determine SHA of last successful commit. Using SHA for current commit.");
+            sha = triggeringSha;
         }
 
         core.setOutput('sha', sha);


### PR DESCRIPTION
In repositories where commits will frequently be squashed and force pushed, the list of workflow runs will contain commit SHAs that are no longer actually in the repository. When using commands that depend on a valid SHA (such as the [nx affected](https://nx.dev/latest/react/cli/affected) command), this will cause problems in subsequent steps.

This PR introduces an optional, disabled by default, way to validate the SHA of a workflow run against the list of commits actually in the repository.

Note that this will require the checkout step to increase the depth of the checked out tree - the README has been updated to reflect this requirement.