### PR TITLE
Fix Last build being skipped

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9602,17 +9602,18 @@ function run() {
                     core.debug(`Run SHA: ${run.head_sha}`);
                     core.debug(`Run Branch: ${run.head_branch}`);
                     core.debug(`Wanted branch: ${inputs.branch}`);
-                    if (triggeringSha != run.head_sha && (!inputs.branch || run.head_branch === inputs.branch)) {
-                        if (inputs.verify && !(yield verifyCommit(run.head_sha))) {
-                            core.warning(`Failed to verify commit ${run.head_sha}. Skipping.`);
-                            continue;
-                        }
-                        core.info(inputs.verify
-                            ? `Commit ${run.head_sha} from run ${run.html_url} verified as last successful CI run.`
-                            : `Using ${run.head_sha} from run ${run.html_url} as last successful CI run.`);
-                        sha = run.head_sha;
-                        break;
+                    if (!inputs.branch || run.head_branch !== inputs.branch) {
+                        continue;
                     }
+                    if (inputs.verify && !(yield verifyCommit(run.head_sha))) {
+                        core.warning(`Failed to verify commit ${run.head_sha}. Skipping.`);
+                        continue;
+                    }
+                    core.info(inputs.verify
+                        ? `Commit ${run.head_sha} from run ${run.html_url} verified as last successful CI run.`
+                        : `Using ${run.head_sha} from run ${run.html_url} as last successful CI run.`);
+                    sha = run.head_sha;
+                    break;
                 }
             }
             else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,21 +67,23 @@ async function run(): Promise<void> {
                 core.debug(`Run Branch: ${run.head_branch}`);
                 core.debug(`Wanted branch: ${inputs.branch}`);
 
-                if (triggeringSha != run.head_sha && (!inputs.branch || run.head_branch === inputs.branch)) {
-                    if (inputs.verify && !await verifyCommit(run.head_sha)) {
-                        core.warning(`Failed to verify commit ${run.head_sha}. Skipping.`);
-                        continue;
-                    }
-
-                    core.info(
-                      inputs.verify
-                      ? `Commit ${run.head_sha} from run ${run.html_url} verified as last successful CI run.`
-                      : `Using ${run.head_sha} from run ${run.html_url} as last successful CI run.`
-                    );
-                    sha = run.head_sha;
-
-                    break;
+                if (!inputs.branch || !run.head_branch === inputs.branch){
+                    continue;
                 }
+
+                if (inputs.verify && !await verifyCommit(run.head_sha)) {
+                    core.warning(`Failed to verify commit ${run.head_sha}. Skipping.`);
+                    continue;
+                }
+
+                core.info(
+                    inputs.verify
+                    ? `Commit ${run.head_sha} from run ${run.html_url} verified as last successful CI run.`
+                    : `Using ${run.head_sha} from run ${run.html_url} as last successful CI run.`
+                );
+                sha = run.head_sha;
+
+                break;
             }
         } else {
             core.info(`No previous runs found for branch ${inputs.branch}.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ async function run(): Promise<void> {
                 core.debug(`Run Branch: ${run.head_branch}`);
                 core.debug(`Wanted branch: ${inputs.branch}`);
 
-                if (!inputs.branch || run.head_branch !== inputs.branch){
+                if (inputs.branch && run.head_branch !== inputs.branch){
                     continue;
                 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ async function run(): Promise<void> {
                 core.debug(`Run Branch: ${run.head_branch}`);
                 core.debug(`Wanted branch: ${inputs.branch}`);
 
-                if (!inputs.branch || !run.head_branch === inputs.branch){
+                if (!inputs.branch || run.head_branch !== inputs.branch){
                     continue;
                 }
 


### PR DESCRIPTION
Due to the "triggeringSha != run.head_sha" check, the action would never return a build that used the same sha as the current commit, and would instead return the build before the previous one.

So if the current head was the last run, then the run before that would be used.